### PR TITLE
Fix issue 21.

### DIFF
--- a/src/Help/Page/Help.hs
+++ b/src/Help/Page/Help.hs
@@ -162,7 +162,8 @@ plainP = do
   spaces <- takeWhileP Nothing isSpace
   ind <- getIndent
   modify (set curPlainIndent (Just ind))
-  rest <- takeWhile1P' (/= '\n') <* optional newline
+  let takeMore = if T.null spaces then takeWhile1P else takeWhileP
+  rest <- takeMore Nothing (/= '\n') <* optional newline
   pure $ Plain (T.snoc (spaces <> rest) '\n')
 
 ------------------------------------------------------------


### PR DESCRIPTION
We might hit EOF between having consumed the first set of spaces and trying to consume the second set of spaces. If the first set is empty, then we demand that there is at least one or more characters left to consume, so that we don't get stuck in an infinite loop. If the first set is non-empty, it is possible that we consume zero spaces, because we hit EOF.